### PR TITLE
feat(economy): add regret button to ladder

### DIFF
--- a/src/modules/economy/mutations.hooks.ts
+++ b/src/modules/economy/mutations.hooks.ts
@@ -17,6 +17,7 @@ import {
   JOIN_RANKED_SEASON_MUTATION,
   PLACE_PROUCT_ORDER_MUTATION,
   PLACE_SOCI_ORDER_SESSION_ORDER_MUTATION,
+  REVOKE_RANKED_CONSENT_MUTATION,
   SOCI_ORDER_SESSION_NEXT_STATUS_MUTATION,
   UNDO_PRODUCT_ORDER_MUTATION,
 } from './mutations'
@@ -172,7 +173,12 @@ export function useSociRankedSeasonMutations() {
     JOIN_RANKED_SEASON_MUTATION
   )
 
+  const [revokeRankedConsent, { loading: revokeConsentLoading }] =
+    useMutation<SuccessPayload>(REVOKE_RANKED_CONSENT_MUTATION)
+
   return {
     joinRankedSeason,
+    revokeRankedConsent,
+    revokeConsentLoading,
   }
 }

--- a/src/modules/economy/mutations.ts
+++ b/src/modules/economy/mutations.ts
@@ -188,3 +188,12 @@ export const JOIN_RANKED_SEASON_MUTATION = gql`
     }
   }
 `
+
+export const REVOKE_RANKED_CONSENT_MUTATION = gql`
+  mutation RevokeRankedConsentMutation {
+    revokeRankedConsent {
+      success
+      message
+    }
+  }
+`

--- a/src/modules/economy/queries.ts
+++ b/src/modules/economy/queries.ts
@@ -309,6 +309,7 @@ export const CURRENT_SEASON_QUERY = gql`
   query CurrentRankSeasonQuery {
     currentRankedSeason {
       isParticipant
+      hasRevokedRankedConsent
       placement
       rankedSeason
       seasonEnd

--- a/src/modules/economy/types.graphql.ts
+++ b/src/modules/economy/types.graphql.ts
@@ -402,6 +402,7 @@ export interface LAST_MARKET_CRASH_QUERY {
 export type RankedSeason = {
   currentRankedSeason: {
     seasonStart: Date
+    hasRevokedRankedConsent: boolean
     rankedSeason: number
     seasonEnd: Date | null
     participantCount: number | null

--- a/src/modules/users/components/UserDetails.tsx
+++ b/src/modules/users/components/UserDetails.tsx
@@ -17,6 +17,7 @@ import {
   IconBook2,
   IconCake,
   IconHome,
+  IconIceSkating,
   IconMapPin,
   IconPhone,
   IconSchool,
@@ -85,7 +86,10 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ user, onClick }) => {
             <IconWithData icon={IconPhone} userData={user.phone} type="tel" />
             <IconWithData icon={IconHome} userData={user.homeTown} />
             <IconWithData icon={IconMapPin} userData={user.studyAddress} />
-            <IconWithData icon={IconSchool} userData={user.study} />
+            <IconWithData
+              icon={user.hasRevokedRankedConsent ? IconIceSkating : IconSchool}
+              userData={user.study}
+            />
             <IconWithData icon={IconCake} userData={user.dateOfBirth} />
             <Group spacing={'xs'} className={classes.bio} noWrap mt={'xl'}>
               <Text className={classes.aboutMe}>Om meg</Text>

--- a/src/modules/users/queries.ts
+++ b/src/modules/users/queries.ts
@@ -32,6 +32,7 @@ export const USER_QUERY = gql`
   query User($id: ID!) {
     user(id: $id) {
       id
+      hasRevokedRankedConsent
       getFullWithNickName
       getCleanFullName
       firstName

--- a/src/modules/users/types.ts
+++ b/src/modules/users/types.ts
@@ -53,6 +53,7 @@ export type UserNode = {
   notifyOnShift: boolean
   notifyOnDeposit: boolean
   canRewriteAboutMe: boolean
+  hasRevokedRankedConsent: boolean
   bankAccount: {
     id: string
     cardUuid: string

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -45,6 +45,7 @@ export const UserPlaceholder: UserNode = {
   notifyOnShift: false,
   notifyOnDeposit: false,
   canRewriteAboutMe: false,
+  hasRevokedRankedConsent: false,
   legacyWorkHistory: [],
   homeTown: '',
   bankAccount: {


### PR DESCRIPTION
Users are able to revoke participation consent. However this will
blacklist them from joining the current season again. Revoke consent
has to be reset manually in the backend. People who regret joining
however are probably prone to not joining the next time.

Leave this as is. If someone explicitly complains about not being
able to rejoin we can reset on a per-case basis
