### PR TITLE
refactor/fix: enum casts, navbar active state, whats new modal

### DIFF
--- a/src/components/Select/DaySelect.tsx
+++ b/src/components/Select/DaySelect.tsx
@@ -1,5 +1,6 @@
 import { Select } from '@mantine/core'
 import { DayValues } from 'modules/schedules/consts'
+import { enumHandler } from 'util/parsing'
 
 interface DaySelectProps {
   value: DayValues
@@ -24,7 +25,7 @@ export const DaySelect: React.FC<DaySelectProps> = ({
     <Select
       label="Dag i uken"
       value={value}
-      onChange={val => val && onChangeCallback(val as DayValues)}
+      onChange={enumHandler(DayValues, onChangeCallback)}
       data={data}
     />
   )

--- a/src/components/WhatsNewNotification/WhatsNewNotification.tsx
+++ b/src/components/WhatsNewNotification/WhatsNewNotification.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 
 // Using a hard-coded key value so its easy to force it to unhide.
 // Increment this to force new message
-const NOTIFICATION_KEY = '2024-09-21'
+const NOTIFICATION_KEY = '2026-03-03'
 
 export const WhatsNewNotification: React.FC = () => {
   const firstRender = useRef(true)
@@ -32,7 +32,15 @@ export const WhatsNewNotification: React.FC = () => {
         👋 Hva er nytt?
       </Title>
       <Text size="sm" c="gray" mt={0}>
-        Siste oppdatering: 2024-09-21
+        Siste oppdatering: 2026-03-03
+      </Text>
+      <Divider mb="md" />
+      <Title order={4}>Oppgradering - 3. Mars 2026</Title>
+      <Text>
+        KSG-nett har fått en større oppgradering av UI-biblioteket vi bruker.
+        Det meste er under panseret, men noen ting kan ende opp med å se litt
+        rart ut eller slutte å funke. Om du legger merke til noe gjerne, gi
+        beskjed til KSG-IT (ksg-it@samfundet.no).
       </Text>
       <Divider mb="md" />
       <Title order={4}>Arkivering av funksjonærbeskrivelser</Title>

--- a/src/containers/NavItem.tsx
+++ b/src/containers/NavItem.tsx
@@ -47,6 +47,7 @@ const useNavItemStyles = createStyles((t, { active }: { active: boolean }) => ({
     width: '100%',
     borderRadius: t.radius.sm,
     padding: `8px 4px`,
+    backgroundColor: active ? t.colors['samfundet-red'][5] : undefined,
     '&:hover': {
       backgroundColor: !active ? t.colors.red[0] : 'none',
     },

--- a/src/modules/admissions/components/ConfigureAdmission/PositionAvailabilityInput.tsx
+++ b/src/modules/admissions/components/ConfigureAdmission/PositionAvailabilityInput.tsx
@@ -84,11 +84,7 @@ export const PositionAvailabilityInput: React.VFC<
             { label: 'Funksjonær', value: 'FUNCTIONARY' },
             { label: 'Gjengmedlem', value: 'GANG_MEMBER' },
           ]}
-          onChange={val =>
-            handleMembershipTypeChange(
-              val as 'GANG_MEMBER' | 'FUNCTIONARY' | null
-            )
-          }
+          onChange={val => handleMembershipTypeChange(val)}
           defaultValue={availablePosition.membershipType}
         />
       </td>

--- a/src/modules/admissions/components/EditInterview/AdditionalEvaluationInline.tsx
+++ b/src/modules/admissions/components/EditInterview/AdditionalEvaluationInline.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client'
 import { Group, Select } from '@mantine/core'
 import { InterviewAdditionalEvaluationAnswerValues } from 'modules/admissions/consts'
+import { enumHandler, parseEnum } from 'util/parsing'
 import { PATCH_INTERVIEW_ADDITIONAL_EVALUATION_ANSWER } from 'modules/admissions/mutations'
 import { additionalEvaluationOptions } from 'modules/admissions/options'
 import {
@@ -28,33 +29,24 @@ export const AdditionalEvaluationInline: React.VFC<
   const handleChange = (selected: string | null) => {
     if (selected === additionalEvaluation.answer) return
 
-    const parsedValue =
-      selected === '' || selected === null
-        ? null
-        : (selected as InterviewAdditionalEvaluationAnswerValues)
+    const parsed = selected
+      ? parseEnum(InterviewAdditionalEvaluationAnswerValues, selected)
+      : null
 
     patchAnswer({
       variables: {
         id: additionalEvaluation.id,
-        input: {
-          answer: parsedValue,
-        },
+        input: { answer: parsed },
       },
     })
-    setSelectedValue(
-      (selected ?? '') as InterviewAdditionalEvaluationAnswerValues | ''
-    )
+    setSelectedValue(parsed ?? '')
   }
 
   return (
     <Group>
       <Select
         label={additionalEvaluation.statement.statement}
-        onChange={val =>
-          handleChange(
-            (val ?? '') as InterviewAdditionalEvaluationAnswerValues | ''
-          )
-        }
+        onChange={handleChange}
         value={selectedValue}
         data={additionalEvaluationOptions}
       />

--- a/src/modules/admissions/components/EditInterview/AdditionalInformationFields.tsx
+++ b/src/modules/admissions/components/EditInterview/AdditionalInformationFields.tsx
@@ -2,7 +2,7 @@ import { Radio, Stack } from '@mantine/core'
 import { usePatchApplicant } from 'modules/admissions/mutations.hooks'
 import { ApplicantNode } from 'modules/admissions/types.graphql'
 import { useState } from 'react'
-import { booleanToRadio, radioToBoolean } from 'util/parsing'
+import { booleanToRadio, radioToBoolean, yesNoHandler } from 'util/parsing'
 
 interface AdditionalInformationFieldsProps {
   applicant: Pick<
@@ -23,39 +23,31 @@ export const AdditionalInformationFields: React.VFC<
 
   const { patchApplicant } = usePatchApplicant()
 
-  const handleChangeCanCommit = (val: string) => {
-    setCanCommitThreeSemesters(val as '' | 'yes' | 'no')
-    const parsedCanCommitThreeSemesters = radioToBoolean(
-      val as '' | 'yes' | 'no'
-    )
+  const handleChangeCanCommit = yesNoHandler(yesNo => {
+    setCanCommitThreeSemesters(yesNo)
     patchApplicant({
       variables: {
         id: applicant.id,
-        input: {
-          canCommitThreeSemesters: parsedCanCommitThreeSemesters,
-        },
+        input: { canCommitThreeSemesters: radioToBoolean(yesNo) },
       },
     })
-  }
+  })
 
-  const handleChangeOpenForOtherPositions = (val: string) => {
-    setOpenForOtherPositions(val as '' | 'yes' | 'no')
-    const parsedOpenForOtherPositions = radioToBoolean(val as '' | 'yes' | 'no')
+  const handleChangeOpenForOtherPositions = yesNoHandler(yesNo => {
+    setOpenForOtherPositions(yesNo)
     patchApplicant({
       variables: {
         id: applicant.id,
-        input: {
-          openForOtherPositions: parsedOpenForOtherPositions,
-        },
+        input: { openForOtherPositions: radioToBoolean(yesNo) },
       },
     })
-  }
+  })
 
   return (
     <Stack>
       <Radio.Group
         label="Kandidat åpen for andre verv?"
-        onChange={val => handleChangeOpenForOtherPositions(val as 'yes' | 'no')}
+        onChange={handleChangeOpenForOtherPositions}
         value={openForOtherPositions}
       >
         <Radio value="yes" label="Ja" />
@@ -63,7 +55,7 @@ export const AdditionalInformationFields: React.VFC<
       </Radio.Group>
       <Radio.Group
         label="Kan bli i 3 semestre?"
-        onChange={val => handleChangeCanCommit(val as 'yes' | 'no')}
+        onChange={handleChangeCanCommit}
         value={canCommitThreeSemesters}
       >
         <Radio value="yes" label="Ja" />

--- a/src/modules/admissions/components/EditInterview/BooleanEvaluationInline.tsx
+++ b/src/modules/admissions/components/EditInterview/BooleanEvaluationInline.tsx
@@ -7,7 +7,7 @@ import {
 } from 'modules/admissions/types.graphql'
 import React, { useState } from 'react'
 import { PatchMutationVariables } from 'types/graphql'
-import { booleanToRadio, radioToBoolean } from 'util/parsing'
+import { booleanToRadio, radioToBoolean, yesNoHandler } from 'util/parsing'
 
 interface BooleanEvaluationInlineProps {
   booleanEvaluationAnswer: InterviewBooleanEvaluationAnswerNode
@@ -25,23 +25,21 @@ export const BooleanEvaluationInline: React.FC<
     PatchMutationVariables<InterviewBooleanEvaluationAnswerNode>
   >(PATCH_INTERVIEW_BOOLEAN_EVALUATION_ANSWER)
 
-  const handleChange = (val: string) => {
-    setValue(val as '' | 'yes' | 'no')
-    const parsedValue = radioToBoolean(val as '' | 'yes' | 'no')
-
+  const handleChange = yesNoHandler(yesNo => {
+    setValue(yesNo)
     patchBooleanEvaluationAnswer({
       variables: {
         id: booleanEvaluationAnswer.id,
-        input: { value: parsedValue },
+        input: { value: radioToBoolean(yesNo) },
       },
     })
-  }
+  })
 
   return (
     <Group>
       <Radio.Group
         value={value}
-        onChange={val => handleChange(val as 'yes' | 'no')}
+        onChange={handleChange}
         label={booleanEvaluationAnswer.statement.statement}
       >
         <Group>

--- a/src/modules/admissions/components/EditInterview/TotalEvaluationSelect.tsx
+++ b/src/modules/admissions/components/EditInterview/TotalEvaluationSelect.tsx
@@ -4,6 +4,7 @@ import { useInterviewMutations } from 'modules/admissions/mutations.hooks'
 import { INTERVIEW_DETAIL_QUERY } from 'modules/admissions/queries'
 import { InterviewNode } from 'modules/admissions/types.graphql'
 import { useState } from 'react'
+import { enumHandler } from 'util/parsing'
 
 const totalEvaluationOptions = [
   {
@@ -38,15 +39,12 @@ export const TotalEvaluationSelect: React.VFC<TotalEvaluationSelectProps> = ({
   const [selectedValue, setSelectedValue] = useState(interview.totalEvaluation)
   const { patchInterview } = useInterviewMutations()
 
-  const handleChange = (value: string | null) => {
-    if (!value) return
-    setSelectedValue(value as InterviewTotalEvaluationValues)
+  const handleChange = (parsed: InterviewTotalEvaluationValues) => {
+    setSelectedValue(parsed)
     patchInterview({
       variables: {
         id: interview.id,
-        input: {
-          totalEvaluation: value as InterviewTotalEvaluationValues,
-        },
+        input: { totalEvaluation: parsed },
       },
       refetchQueries: [INTERVIEW_DETAIL_QUERY],
     })
@@ -59,9 +57,7 @@ export const TotalEvaluationSelect: React.VFC<TotalEvaluationSelectProps> = ({
       placeholder="Velg verdi"
       value={selectedValue}
       data={totalEvaluationOptions}
-      onChange={val =>
-        val && handleChange(val as InterviewTotalEvaluationValues)
-      }
+      onChange={enumHandler(InterviewTotalEvaluationValues, handleChange)}
     />
   )
 }

--- a/src/modules/admissions/views/InternalGroupDiscussion.tsx
+++ b/src/modules/admissions/views/InternalGroupDiscussion.tsx
@@ -13,6 +13,7 @@ import {
   FreeForAllApplicantsTable,
 } from '../components/DiscussionDashboard'
 import { InternalGroupDiscussionDataOrderingKeyValue } from '../consts'
+import { enumHandler } from 'util/parsing'
 import { INTERNAL_GROUP_DISCUSSION_DATA } from '../queries'
 import { InternalGroupDiscussionDataReturns } from '../types.graphql'
 import { createStyles } from '@mantine/emotion'
@@ -97,9 +98,10 @@ export const InternalGroupDiscussion: React.FC = () => {
       <Radio.Group
         label="Sorteringsmodus"
         value={orderingKey}
-        onChange={val =>
-          setOrderingKey(val as InternalGroupDiscussionDataOrderingKeyValue)
-        }
+        onChange={enumHandler(
+          InternalGroupDiscussionDataOrderingKeyValue,
+          setOrderingKey
+        )}
       >
         <Group>
           <Radio

--- a/src/modules/barTab/components/BarTabDashboaard/RegisterProductOrders.tsx
+++ b/src/modules/barTab/components/BarTabDashboaard/RegisterProductOrders.tsx
@@ -23,6 +23,7 @@ import {
 import { ACTIVE_BAR_TAB_QUERY } from 'modules/barTab/queries'
 import { BarTabNode } from 'modules/barTab/types.graphql'
 import { useMemo, useState } from 'react'
+import { enumHandler } from 'util/parsing'
 import { BarTabCustomerSelect } from '../BarTabCustomerSelect'
 import { BarTabProductSelect } from '../BarTabProductSelect'
 import { createStyles } from '@mantine/emotion'
@@ -231,7 +232,7 @@ export const RegisterProductOrders: React.FC<ActiveBarTablControllerProps> = ({
           <Select
             label="Type"
             value={orderType}
-            onChange={val => val && setOrderType(val as BarTabOrderTypeValues)}
+            onChange={enumHandler(BarTabOrderTypeValues, setOrderType)}
             data={[
               {
                 value: BarTabOrderTypeValues.LIST,

--- a/src/modules/economy/components/DepositForm/CreateDepositForm.tsx
+++ b/src/modules/economy/components/DepositForm/CreateDepositForm.tsx
@@ -19,6 +19,7 @@ import { ONGOING_DEPOSIT_INTENT_QUERY } from 'modules/economy/views'
 import { Controller } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 import { useCurrencyFormatter, useMediaQuery } from 'util/hooks'
+import { enumHandler } from 'util/parsing'
 import { StripeDepositPaymentForm } from '../StripeDepositPaymentForm'
 import { useCreateDepositAPI } from './useCreateDepositAPI'
 import { useCreateDepositLogic } from './useCreateDepositLogic'
@@ -80,9 +81,9 @@ export const CreateDepositForm: React.FC<CreateDepositViewProps> = ({
                   <Radio.Group
                     value={field.value}
                     label="Betalingsmåte"
-                    onChange={value =>
-                      setValue('depositMethod', value as DepositMethodValues)
-                    }
+                    onChange={enumHandler(DepositMethodValues, value =>
+                      setValue('depositMethod', value)
+                    )}
                   >
                     <Group>
                       <Radio

--- a/src/modules/economy/components/SociSessions/CreateSociSessionModal.tsx
+++ b/src/modules/economy/components/SociSessions/CreateSociSessionModal.tsx
@@ -13,6 +13,7 @@ import { useSociSessionMutations } from 'modules/economy/mutations.hooks'
 import { ALL_SOCI_SESSIONS } from 'modules/economy/queries'
 import { SociSessionType } from 'modules/economy/types.graphql'
 import { useState } from 'react'
+import { enumHandler } from 'util/parsing'
 import { useNavigate } from 'react-router-dom'
 import { format } from 'util/date-fns'
 
@@ -104,7 +105,7 @@ export const CreateSociSessionModal: React.FC<CreateSociSessionModalProps> = ({
               value: SociSessionType.KRYSSELISTE,
             },
           ]}
-          onChange={val => val && setType(val as SociSessionType)}
+          onChange={enumHandler(SociSessionType, setType)}
         />
         <NumberInput
           label="Minstebeløp gjenværende saldo"

--- a/src/modules/schedules/components/LocationSelect.tsx
+++ b/src/modules/schedules/components/LocationSelect.tsx
@@ -1,5 +1,6 @@
 import { Select, SelectProps } from '@mantine/core'
 import { LocationValues } from '../consts'
+import { enumHandler } from 'util/parsing'
 
 const locationOptions = [
   { value: LocationValues.BODEGAEN, label: 'Bodegaen' },
@@ -31,7 +32,7 @@ export const LocationSelect: React.FC<LocationSelectProps> = ({
     <Select
       data={locationOptions}
       value={value}
-      onChange={val => val && onChange(val as LocationValues)}
+      onChange={enumHandler(LocationValues, onChange)}
       {...rest}
     />
   )

--- a/src/modules/schedules/components/ScheduleRoleSelect.tsx
+++ b/src/modules/schedules/components/ScheduleRoleSelect.tsx
@@ -1,6 +1,7 @@
 import { Select, SelectProps } from '@mantine/core'
 import { RoleValues } from '../consts'
 import { parseShiftRole } from '../util'
+import { enumHandler } from 'util/parsing'
 
 const shiftRoleData = [
   {
@@ -87,7 +88,7 @@ export const ShiftRoleSelect: React.FC<ShiftRoleSelectProps> = ({
   return (
     <Select
       value={value}
-      onChange={val => val && onChangeCallback(val as RoleValues)}
+      onChange={enumHandler(RoleValues, onChangeCallback)}
       data={shiftRoleData}
       {...rest}
     />

--- a/src/util/parsing.ts
+++ b/src/util/parsing.ts
@@ -51,3 +51,53 @@ export const radioToBoolean = (input: '' | 'yes' | 'no') => {
 export const capitalizeFirstLetter = (string: string) => {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
+
+/**
+ * Safely parses a string value into a TypeScript string enum member.
+ * Returns null if the value is not a valid member of the enum.
+ */
+export function parseEnum<T extends Record<string, string>>(
+  enumObj: T,
+  value: string | null
+): T[keyof T] | null {
+  if (value === null) return null
+  return (Object.values(enumObj) as string[]).includes(value)
+    ? (value as T[keyof T])
+    : null
+}
+
+/**
+ * Returns an onChange handler for Mantine Select that validates the value
+ * against a string enum before passing it to the callback.
+ */
+export function enumHandler<T extends Record<string, string>>(
+  enumObj: T,
+  callback: (val: T[keyof T]) => void
+): (val: string | null) => void {
+  return val => {
+    const parsed = parseEnum(enumObj, val)
+    if (parsed !== null) callback(parsed)
+  }
+}
+
+/**
+ * Narrows a Radio.Group string value to the '' | 'yes' | 'no' type
+ * expected by radioToBoolean. Returns null if the value is unexpected.
+ */
+export function parseYesNoRadio(val: string): '' | 'yes' | 'no' | null {
+  if (val === '' || val === 'yes' || val === 'no') return val
+  return null
+}
+
+/**
+ * Returns an onChange handler for Mantine Radio.Group with yes/no options
+ * that narrows the value before passing it to the callback.
+ */
+export function yesNoHandler(
+  callback: (val: '' | 'yes' | 'no') => void
+): (val: string) => void {
+  return val => {
+    const parsed = parseYesNoRadio(val)
+    if (parsed !== null) callback(parsed)
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces all unsafe `val as SomeEnum` casts in Mantine onChange handlers with runtime-validated `enumHandler`/`yesNoHandler` utilities
- Fixes active navbar item being invisible (white text, no background) after Mantine v8 migration
- Updates the "Hva er nytt?" modal with a note about the UI upgrade and a prompt to report issues

## Changes

**Enum casts refactor**
Adds `parseEnum`, `enumHandler`, and `yesNoHandler` to `util/parsing.ts`. Mantine's `Select.onChange` and `Radio.Group.onChange` return `string`, which we were silently casting to typed enums. The new handlers validate via `Object.values()` before invoking the callback.

```ts
onChange={enumHandler(FooEnum, setFoo)}         // replaces: val => setFoo(val as FooEnum)
const handler = yesNoHandler(val => { ... })    // replaces: val => handler(val as 'yes' | 'no')
```

**Navbar active state**
`NavItem` was setting text/icon color to `white` for active items but had no background color, making the label invisible against the white navbar. Fixed by adding `backgroundColor: t.colors['samfundet-red'][5]` for the active state.

**Whats new modal**
Bumped `NOTIFICATION_KEY` to `2026-03-03` so all users see the modal once. New entry (in Norwegian) describes the UI upgrade and asks users to report anything broken.

## Test plan
- [x] Active navbar item shows red background and white text
- [x] "Hva er nytt?" modal appears on first load after clearing localStorage
- [x] `npx tsc --noEmit` passes
- [x] `yarn build` passes